### PR TITLE
chore(ci): Test each supported Moodle version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,6 @@ jobs:
     name: Molecule
     runs-on: ubuntu-22.04
     strategy:
-      max-parallel: 4
       matrix:
         molecule-scenario:
           - default
@@ -67,6 +66,11 @@ jobs:
         ubuntu-version:
           - ubuntu2004
           - ubuntu2204
+        moodle-version:
+          - MOODLE_39_STABLE
+          - MOODLE_400_STABLE
+          - MOODLE_401_STABLE
+          - MOODLE_402_STABLE
 
     steps:
       - name: Check out the codebase.
@@ -88,3 +92,4 @@ jobs:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_DISTRO: ${{ matrix.ubuntu-version }}
+          MOLECULE_MOODLE_VERSION: ${{ matrix.moodle-version }}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,5 +37,6 @@ provisioner:
     host_vars:
       ansible_role_moodle_molecule_${MOLECULE_DISTRO:-ubuntu2204}:
         ansible_user: ubuntu
+        moodle_deploy_version: ${MOLECULE_MOODLE_VERSION:-MOODLE_402_STABLE}
 verifier:
   name: ansible

--- a/molecule/mariadb/molecule.yml
+++ b/molecule/mariadb/molecule.yml
@@ -35,5 +35,6 @@ provisioner:
     host_vars:
       ansible_role_moodle_molecule_${MOLECULE_DISTRO:-ubuntu2204}:
         ansible_user: ubuntu
+        moodle_deploy_version: ${MOLECULE_MOODLE_VERSION:-MOODLE_402_STABLE}
 verifier:
   name: ansible


### PR DESCRIPTION
This means 8 times more test runs. To make the tests go faster, The
upper limit on the number of parallel jobs has been removed. GitHub
Actions will use the maximum number of available workers.

The reason for this change is that installations for different Moodle versions have different requirements, .e.g. for Moodle 3.9, unrecognized options passed to admin/cli/install_database.php does not raise an error, but it does for later versions.